### PR TITLE
Fix file extension filtering.

### DIFF
--- a/LiveSplit.UnrealLoads/GameMemory.cs
+++ b/LiveSplit.UnrealLoads/GameMemory.cs
@@ -160,7 +160,10 @@ namespace LiveSplit.UnrealLoads
 									Debug.WriteLine("[NoLoads] Map is changing from \"{0}\" to \"{1}\" - {2}", prevMap, map, frameCounter);
 								}
 							}
-						if (_status.Changed && _status.Current == (int)Status.LoadingMap)
+
+						}
+
+						if (_status.Changed && _status.Current == Status.LoadingMap)
 						{
 							DoTimerAction(Game.OnMapLoad(_watchers));
 						}

--- a/LiveSplit.UnrealLoads/GameMemory.cs
+++ b/LiveSplit.UnrealLoads/GameMemory.cs
@@ -160,7 +160,6 @@ namespace LiveSplit.UnrealLoads
 									Debug.WriteLine("[NoLoads] Map is changing from \"{0}\" to \"{1}\" - {2}", prevMap, map, frameCounter);
 								}
 							}
-
 						}
 
 						if (_status.Changed && _status.Current == Status.LoadingMap)

--- a/LiveSplit.UnrealLoads/GameMemory.cs
+++ b/LiveSplit.UnrealLoads/GameMemory.cs
@@ -142,19 +142,25 @@ namespace LiveSplit.UnrealLoads
 
 						if (_map.Changed)
 						{
-							if (string.IsNullOrEmpty(Game.MapExtension) ||
-								string.Equals(Path.GetExtension(_map.Current), Game.MapExtension, StringComparison.OrdinalIgnoreCase))
+							string mapname = Path.GetFileNameWithoutExtension(_map.Current);
+							string extension = Path.GetExtension(_map.Current);
+
+							Debug.WriteLine($"Map changed to {_map.Current}, Type: {extension}");
+
+							if (Game.Maps.Count == 0 || Game.Maps.Contains(mapname))
 							{
-								prevMap = map;
-								map = Path.GetFileNameWithoutExtension(_map.Current);
+								if (Game.MapExtension == null ||
+									extension.Equals(Game.MapExtension, StringComparison.OrdinalIgnoreCase))
+								{
+									prevMap = map;
+									map = mapname;
 
-								_uiThread.Post(d => OnMapChange?.Invoke(this, prevMap, map), null);
+									_uiThread.Post(d => OnMapChange?.Invoke(this, prevMap, map), null);
 
-								Debug.WriteLine(string.Format("[NoLoads] Map is changing from \"{0}\" to \"{1}\" - {2}", prevMap, map, frameCounter));
+									Debug.WriteLine("[NoLoads] Map is changing from \"{0}\" to \"{1}\" - {2}", prevMap, map, frameCounter);
+								}
 							}
-						}
-
-						if (_status.Changed && _status.Current == Status.LoadingMap)
+						if (_status.Changed && _status.Current == (int)Status.LoadingMap)
 						{
 							DoTimerAction(Game.OnMapLoad(_watchers));
 						}

--- a/LiveSplit.UnrealLoads/GameMemory.cs
+++ b/LiveSplit.UnrealLoads/GameMemory.cs
@@ -142,8 +142,8 @@ namespace LiveSplit.UnrealLoads
 
 						if (_map.Changed)
 						{
-							if (string.IsNullOrEmpty(Game.MapExtension) || string.IsNullOrEmpty(Path.GetExtension(_map.Current))
-								|| string.Equals(Path.GetExtension(_map.Current), Game.MapExtension, StringComparison.OrdinalIgnoreCase))
+							if (string.IsNullOrEmpty(Game.MapExtension) ||
+								string.Equals(Path.GetExtension(_map.Current), Game.MapExtension, StringComparison.OrdinalIgnoreCase))
 							{
 								prevMap = map;
 								map = Path.GetFileNameWithoutExtension(_map.Current);

--- a/LiveSplit.UnrealLoads/Games/GameSupport.cs
+++ b/LiveSplit.UnrealLoads/Games/GameSupport.cs
@@ -70,5 +70,4 @@ namespace LiveSplit.UnrealLoads.Games
 
 		public virtual TimerAction[] OnDetach(Process game) => new TimerAction[] { TimerAction.PauseGameTime };
 	}
-
 }

--- a/LiveSplit.UnrealLoads/Games/HarryPotter1.cs
+++ b/LiveSplit.UnrealLoads/Games/HarryPotter1.cs
@@ -20,7 +20,7 @@ namespace LiveSplit.UnrealLoads.Games
 			"hp"
 		};
 
-		public override HashSet<string> Maps => new HashSet<string>
+		public override HashSet<string> Maps => new HashSet<string>(StringComparer.OrdinalIgnoreCase)
 		{
 			"Lev_Tut1",
 			"Lev_Tut1b",

--- a/LiveSplit.UnrealLoads/Games/HarryPotter1.cs
+++ b/LiveSplit.UnrealLoads/Games/HarryPotter1.cs
@@ -54,6 +54,11 @@ namespace LiveSplit.UnrealLoads.Games
 			"Snapes_Office"
 		};
 
+		public override TimerAction[] OnDetach(Process game)
+		{
+			return new TimerAction[] { TimerAction.DoNothing };
+		}
+
 		public override TimerAction[] OnMapLoad(MemoryWatcherList watchers)
 		{
 			StringWatcher map = (StringWatcher)watchers["map"];

--- a/LiveSplit.UnrealLoads/Games/HarryPotter1.cs
+++ b/LiveSplit.UnrealLoads/Games/HarryPotter1.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿using LiveSplit.ComponentUtil;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace LiveSplit.UnrealLoads.Games
 {
@@ -50,5 +53,19 @@ namespace LiveSplit.UnrealLoads.Games
 			"Lev5_Snare",
 			"Snapes_Office"
 		};
+
+		public override TimerAction[] OnMapLoad(MemoryWatcherList watchers)
+		{
+			StringWatcher map = (StringWatcher)watchers["map"];
+			if (map != null)
+			{
+				if (!map.Changed && map.Current == "Lev_Tut1.unr")
+				{
+					return new TimerAction[] { TimerAction.Split };
+				}
+			}
+			
+			return new TimerAction[] { TimerAction.UnpauseGameTime };
+		}
 	}
 }

--- a/LiveSplit.UnrealLoads/Games/HarryPotter1.cs
+++ b/LiveSplit.UnrealLoads/Games/HarryPotter1.cs
@@ -56,7 +56,7 @@ namespace LiveSplit.UnrealLoads.Games
 
 		public override TimerAction[] OnDetach(Process game)
 		{
-			return new TimerAction[] { TimerAction.DoNothing };
+			return new TimerAction[] { TimerAction.UnpauseGameTime };
 		}
 
 		public override TimerAction[] OnMapLoad(MemoryWatcherList watchers)
@@ -70,7 +70,7 @@ namespace LiveSplit.UnrealLoads.Games
 				}
 			}
 			
-			return new TimerAction[] { TimerAction.UnpauseGameTime };
+			return new TimerAction[] { TimerAction.DoNothing };
 		}
 	}
 }

--- a/LiveSplit.UnrealLoads/Games/HarryPotter2.cs
+++ b/LiveSplit.UnrealLoads/Games/HarryPotter2.cs
@@ -23,9 +23,7 @@ namespace LiveSplit.UnrealLoads.Games
 			"game"
 		};
 
-		public override string MapExtension { get; } = ".unr";
-
-		public override HashSet<string> Maps => new HashSet<string>
+		public override HashSet<string> Maps => new HashSet<string>(StringComparer.OrdinalIgnoreCase)
 		{
 			"Adv1Willow",
 			"Adv3DungeonQuest",

--- a/LiveSplit.UnrealLoads/Games/HarryPotter2.cs
+++ b/LiveSplit.UnrealLoads/Games/HarryPotter2.cs
@@ -130,5 +130,10 @@ namespace LiveSplit.UnrealLoads.Games
 
 			return commandLine.ToString();
 		}
+
+		public override TimerAction[] OnDetach(Process game)
+		{
+			return new TimerAction[] { TimerAction.UnpauseGameTime };
+		}
 	}
 }

--- a/LiveSplit.UnrealLoads/Games/HarryPotter2.cs
+++ b/LiveSplit.UnrealLoads/Games/HarryPotter2.cs
@@ -69,8 +69,8 @@ namespace LiveSplit.UnrealLoads.Games
 			"Transition"
 		};
 
-		MemoryWatcher<bool> _isSkippingCut = new MemoryWatcher<bool>(new DeepPointer("Engine.dll", 0x2E2DFC, 0x5C));
-		readonly HashSet<int> _moduleMemorySizes = new HashSet<int>
+		private readonly MemoryWatcher<bool> _isSkippingCut = new MemoryWatcher<bool>(new DeepPointer("Engine.dll", 0x2E2DFC, 0x5C));
+		private readonly HashSet<int> _moduleMemorySizes = new HashSet<int>
 		{
 			704512,
 			749568, // US

--- a/LiveSplit.UnrealLoads/Games/HarryPotter3.cs
+++ b/LiveSplit.UnrealLoads/Games/HarryPotter3.cs
@@ -1,13 +1,12 @@
 ﻿using System.Collections.Generic;
 using LiveSplit.ComponentUtil;
 using System;
+using System.Diagnostics;
 
 namespace LiveSplit.UnrealLoads.Games
 {
 	class HarryPotter3 : GameSupport
 	{
-		public override string MapExtension { get; } = ".unr";
-
 		public override HashSet<string> GameNames => new HashSet<string>
 		{
 			"Harry Potter 3",
@@ -61,10 +60,20 @@ namespace LiveSplit.UnrealLoads.Games
 		{
 			var map = (StringWatcher)watchers["map"];
 
-			if (map.Current.Equals("hp3_adv1express.unr", StringComparison.OrdinalIgnoreCase))
-				return new TimerAction[] { TimerAction.Start };
-			else
-				return null;
+			if (map != null)
+			{
+				if (map.Current.Equals("hp3_adv1express.unr", StringComparison.OrdinalIgnoreCase))
+				{
+					return new TimerAction[] { TimerAction.Start };
+				}
+			}	
+
+			return new TimerAction[] { TimerAction.DoNothing };
+		}
+
+		public override TimerAction[] OnDetach(Process game)
+		{
+			return new TimerAction[] { TimerAction.UnpauseGameTime };
 		}
 	}
 }

--- a/LiveSplit.UnrealLoads/Games/HarryPotter3.cs
+++ b/LiveSplit.UnrealLoads/Games/HarryPotter3.cs
@@ -20,7 +20,7 @@ namespace LiveSplit.UnrealLoads.Games
 			"hppoa"
 		};
 
-		public override HashSet<string> Maps => new HashSet<string>
+		public override HashSet<string> Maps => new HashSet<string>(StringComparer.OrdinalIgnoreCase)
 		{
 			"hp3_adv1express",
 			"hp3_groundsdada",


### PR DESCRIPTION
Due to the way unreal engine works, filtering maps by file extension just straight up doesn't work sometimes. This pull request changes the behavior such that if a game has a file extension of `null` specified, the autosplitter won't attempt to match file extensions. I've also tweaked some behavior for the Harry Potter games at the moderators' resquest. Specifically, they don't want to the game time to pause on exiting the game, so I made it give the unpause command. This was necessary to fix an issue where sometimes the program would interpret the game exiting as a load and the time would refuse to unpause. Some miscellaneous vars in the HP2 GameSupport class were changed to be private readonly because they're never supposed to be changed or accessed from outside the class.