### PR TITLE
Spintercell fix

### DIFF
--- a/LiveSplit.UnrealLoads/Games/SplinterCell.cs
+++ b/LiveSplit.UnrealLoads/Games/SplinterCell.cs
@@ -10,6 +10,7 @@ namespace LiveSplit.UnrealLoads.Games
 		public override HashSet<string> GameNames => new HashSet<string>
 		{
 			"Splinter Cell",
+			"Tom Clancy's Splinter Cell"
 		};
 
 		public override HashSet<string> ProcessNames => new HashSet<string>

--- a/LiveSplit.UnrealLoads/Games/SplinterCell.cs
+++ b/LiveSplit.UnrealLoads/Games/SplinterCell.cs
@@ -18,7 +18,7 @@ namespace LiveSplit.UnrealLoads.Games
 			"splintercell"
 		};
 
-		public override HashSet<string> Maps => new HashSet<string>
+		public override HashSet<string> Maps => new HashSet<string>(StringComparer.OrdinalIgnoreCase)
 		{
 			"0_0_2_training",
 			"0_0_3_training",

--- a/LiveSplit.UnrealLoads/Games/SplinterCell3.cs
+++ b/LiveSplit.UnrealLoads/Games/SplinterCell3.cs
@@ -20,7 +20,7 @@ namespace LiveSplit.UnrealLoads.Games
 			"splintercell3"
 		};
 
-		public override HashSet<string> Maps { get; } = new HashSet<string>
+		public override HashSet<string> Maps { get; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
 		{
 			"01_panama",
 			"02_cargoship",

--- a/LiveSplit.UnrealLoads/Games/SplinterCell3.cs
+++ b/LiveSplit.UnrealLoads/Games/SplinterCell3.cs
@@ -11,7 +11,8 @@ namespace LiveSplit.UnrealLoads.Games
 		{
 			"Splinter Cell 3",
 			"Splinter Cell: Chaos Theory",
-			"Splinter Cell Chaos Theory"
+			"Splinter Cell Chaos Theory",
+			"Tom Clancy's Splinter Cell:Chaos Theory"
 		};
 
 		public override HashSet<string> ProcessNames { get; } = new HashSet<string>


### PR DESCRIPTION
I added the official speedrun.com names as game names for splinter cell 1 & 3 and I made the hashset containing the mapnames case-insensitive, fixing #13 