### PR TITLE
Fix splitting when loading a save

### DIFF
--- a/LiveSplit.UnrealLoads.Tests/LiveSplit.UnrealLoads.Tests.csproj
+++ b/LiveSplit.UnrealLoads.Tests/LiveSplit.UnrealLoads.Tests.csproj
@@ -1,0 +1,38 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net461</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="AutoFixture" Version="4.15.0" />
+    <PackageReference Include="AutoFixture.AutoNSubstitute" Version="4.15.0" />
+    <PackageReference Include="AutoFixture.Xunit2" Version="4.15.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="NSubstitute" Version="4.2.2" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="Xunit.Combinatorial" Version="1.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="1.3.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\LiveSplit.UnrealLoads\LiveSplit.UnrealLoads.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Reference Include="LiveSplit.Core">
+      <HintPath>..\..\..\..\Program Files\LiveSplit\LiveSplit.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Windows.Forms" />
+  </ItemGroup>
+
+</Project>

--- a/LiveSplit.UnrealLoads.Tests/UnrealLoadsComponentTests.cs
+++ b/LiveSplit.UnrealLoads.Tests/UnrealLoadsComponentTests.cs
@@ -1,0 +1,161 @@
+﻿using AutoFixture;
+using AutoFixture.AutoNSubstitute;
+using AutoFixture.Xunit2;
+using LiveSplit.Model;
+using NSubstitute;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace LiveSplit.UnrealLoads.Tests
+{
+	public class UnrealLoadsComponentTests
+    {
+		private readonly IFixture _fixture;
+		private readonly IUnrealLoadsSettings _settings;
+		private readonly IGameMemory _gameMemory;
+		private readonly ITimerModel _timer;
+		private readonly LiveSplitState _state;
+		private readonly UnrealLoadsComponent _sut;
+
+		public UnrealLoadsComponentTests()
+		{
+			_fixture = new Fixture().Customize(new AutoNSubstituteCustomization() { ConfigureMembers = true });
+
+			_settings = _fixture.Create<IUnrealLoadsSettings>();
+			_settings.DbgShowMap = false;
+			_settings.AutoReset
+				= _settings.AutoStart
+				= _settings.AutoSplitOncePerMap
+				= _settings.AutoSplitOnMapChange = true;
+
+			_state = new LiveSplitState(null, null, null, null, null);
+			_gameMemory = Substitute.For<IGameMemory>();
+			_timer = Substitute.For<ITimerModel>();
+
+			_sut = new UnrealLoadsComponent(_state, _timer, _gameMemory, _settings);
+		}
+
+		[Theory, AutoData]
+		public void WhenMapChange_EnteringEnabledMapAndExitingUnlistedMap_ShouldSplit( Map enterMap, string prevMap)
+		{
+			_settings.Maps.Add(enterMap);
+			enterMap.SplitOnEnter = true;
+			enterMap.SplitOnLeave = false;
+
+
+			string nextMap = enterMap.Name.ToUpperInvariant();
+			_gameMemory.OnMapChange += Raise.Event<MapChangeEventHandler>(_gameMemory, prevMap, nextMap);
+
+
+			_timer.ReceivedWithAnyArgs(1).Split();
+        }
+
+		[Theory, AutoData]
+		public void WhenMapChange_LeavingEnabledMapAndEnteringListedMap_DifferentLettercase_ShouldSplit(Map exitMap, Map enterMap)
+		{
+			_settings.Maps.Add(exitMap);
+			_settings.Maps.Add(enterMap);
+			exitMap.SplitOnLeave = true;
+			exitMap.SplitOnEnter = false;
+			enterMap.SplitOnLeave = false;
+			enterMap.SplitOnEnter = false;
+
+
+			string prevMap = exitMap.Name.ToUpperInvariant();
+			string nextMap = enterMap.Name.ToUpperInvariant();
+			_gameMemory.OnMapChange += Raise.Event<MapChangeEventHandler>(_gameMemory, prevMap, nextMap);
+
+
+			_timer.ReceivedWithAnyArgs(1).Split();
+        }
+
+        [Theory, AutoData]
+        public void WhenMapChange_LeavingEnabledMapAndEnteringUnlistedMap_ShouldNotSplit(Map exitMap, string nextMap)
+        {
+			_settings.Maps.Add(exitMap);
+			exitMap.SplitOnLeave = true;
+
+
+			string prevMap = exitMap.Name.ToUpperInvariant();
+			_gameMemory.OnMapChange += Raise.Event<MapChangeEventHandler>(_gameMemory, prevMap, nextMap);
+
+
+			_timer.DidNotReceiveWithAnyArgs().Split();
+        }
+
+		[Theory, CombinatorialData]
+		public void WhenMapChangeTwice_EmptyMapList_ShouldSplitTwiceWithAnySplitHistorySetting(bool splitOnlyOnce)
+		{
+			// Arrange
+			_settings.AutoSplitOncePerMap = splitOnlyOnce;
+
+			_settings.Maps.Clear();
+			var prevMap = _fixture.Create<string>();
+			var nextMap = _fixture.Create<string>();
+			_gameMemory.OnMapChange += Raise.Event<MapChangeEventHandler>(_gameMemory, prevMap, nextMap);
+
+			// Act
+			_gameMemory.OnMapChange += Raise.Event<MapChangeEventHandler>(_gameMemory, prevMap, nextMap);
+
+			// Assert
+			_timer.ReceivedWithAnyArgs(2).Split();
+		}
+
+		[Theory]
+		[MemberData(nameof(GetCasesThatShouldSplit), true)]
+		[MemberData(nameof(GetCasesThatShouldSplit), false)]
+		public void WhenMapChangeTwice_ShouldSplitOnlyOnceIfOptionEnabled(Map exitMap, Map enterMap, bool splitOnlyOnce)
+		{
+			// Arrange
+			_settings.AutoSplitOncePerMap = splitOnlyOnce;
+
+			if (exitMap != null) _settings.Maps.Add(exitMap);
+			if (enterMap != null) _settings.Maps.Add(enterMap);
+			var prevMap = exitMap?.Name.ToUpperInvariant() ?? _fixture.Create<string>();
+			var nextMap = enterMap?.Name.ToUpperInvariant() ?? _fixture.Create<string>();
+			_gameMemory.OnMapChange += Raise.Event<MapChangeEventHandler>(_gameMemory, prevMap, nextMap);
+
+			// Act
+			_gameMemory.OnMapChange += Raise.Event<MapChangeEventHandler>(_gameMemory, prevMap, nextMap);
+
+			// Assert
+			_timer.ReceivedWithAnyArgs(splitOnlyOnce ? 1 : 2).Split();
+		}
+
+		public static IEnumerable<object[]> GetCasesThatShouldSplit(bool splitonlyonce)
+		{
+			var exitMapName = Guid.NewGuid().ToString().ToLowerInvariant();
+			var enterMapName = Guid.NewGuid().ToString().ToLowerInvariant();
+
+			// 1. leaving an unlisted map, entering an enabled map
+			yield return new object[]
+			{
+				null,
+				new Map(enterMapName) { SplitOnEnter = true },
+				splitonlyonce
+			};
+			// 2. leaving a listed map, entering an enabled map
+			yield return new object[]
+			{
+				new Map(exitMapName),
+				new Map(enterMapName) { SplitOnEnter = true },
+				splitonlyonce
+			};
+			// 3. leaving an enabled map, entering a listed map
+			yield return new object[]
+			{
+				new Map(exitMapName) { SplitOnLeave = true },
+				new Map(enterMapName),
+				splitonlyonce
+			};
+			// 4. leaving and entering enabled maps
+			yield return new object[]
+			{
+				new Map(exitMapName) { SplitOnLeave = true },
+				new Map(enterMapName) { SplitOnEnter = true },
+				splitonlyonce
+			};
+		}
+    }
+}

--- a/LiveSplit.UnrealLoads.sln
+++ b/LiveSplit.UnrealLoads.sln
@@ -1,9 +1,11 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.23107.0
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31025.194
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LiveSplit.UnrealLoads", "LiveSplit.UnrealLoads\LiveSplit.UnrealLoads.csproj", "{2307542D-1ACA-4B3C-A9CE-DCD1EDC6AA23}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LiveSplit.UnrealLoads.Tests", "LiveSplit.UnrealLoads.Tests\LiveSplit.UnrealLoads.Tests.csproj", "{9B44BAC1-C872-4089-8148-228E397B223D}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -15,8 +17,15 @@ Global
 		{2307542D-1ACA-4B3C-A9CE-DCD1EDC6AA23}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2307542D-1ACA-4B3C-A9CE-DCD1EDC6AA23}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2307542D-1ACA-4B3C-A9CE-DCD1EDC6AA23}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9B44BAC1-C872-4089-8148-228E397B223D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9B44BAC1-C872-4089-8148-228E397B223D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9B44BAC1-C872-4089-8148-228E397B223D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9B44BAC1-C872-4089-8148-228E397B223D}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {7BDDD8A8-62E2-4F9C-9FCD-9E1A30C8987A}
 	EndGlobalSection
 EndGlobal

--- a/LiveSplit.UnrealLoads/GameMemory.cs
+++ b/LiveSplit.UnrealLoads/GameMemory.cs
@@ -19,30 +19,12 @@ namespace LiveSplit.UnrealLoads
 		Saving = 2
 	}
 
-	class GameMemory
+	public class GameMemory : IGameMemory
 	{
 		public const int SLEEP_TIME = 15;
 
-		public static readonly GameSupport[] SupportedGames = new GameSupport[]
-		{
-			new HarryPotter1(),
-			new HarryPotter2(),
-			new HarryPotter3(),
-			new Shrek2(),
-			new WheelOfTime(),
-			new UnrealGold(),
-			new SplinterCell3(),
-			new SplinterCell(),
-			new MobileForces(),
-			new XCOM_Enforcer(),
-			new DS9TheFallen(),
-			new KlingonHonorGuard()
-		};
-
-		public static readonly string[] SupportedProcessesNames =
-			SupportedGames.SelectMany(g => g.ProcessNames
-				.Select(pName => pName.ToLower()))
-				.ToArray();
+		readonly GameSupport[] SupportedGames;
+		readonly string[] SupportedProcessesNames;
 
 		public event EventHandler OnReset;
 		public event EventHandler OnStart;
@@ -50,9 +32,8 @@ namespace LiveSplit.UnrealLoads
 		public event EventHandler OnLoadStarted;
 		public event EventHandler OnLoadEnded;
 		public event MapChangeEventHandler OnMapChange;
-		public delegate void MapChangeEventHandler(object sender, string prevMap, string nextMap);
 
-		public GameSupport Game { get; private set; }
+		private GameSupport Game { get; set; }
 
 		Task _thread;
 		CancellationTokenSource _cancelSource;
@@ -71,8 +52,13 @@ namespace LiveSplit.UnrealLoads
 
 		readonly int MAP_SIZE = Encoding.Unicode.GetMaxByteCount(260); // MAX_PATH == 260
 
-		public GameMemory()
+		public GameMemory(IEnumerable<GameSupport> supportedGames)
 		{
+			SupportedGames = supportedGames.ToArray();
+			SupportedProcessesNames = SupportedGames.SelectMany(g => g.ProcessNames
+				.Select(pName => pName.ToLower()))
+				.ToArray();
+
 			_ignorePIDs = new HashSet<int>();
 			_watchers = new MemoryWatcherList();
 		}

--- a/LiveSplit.UnrealLoads/Games/GameSupport.cs
+++ b/LiveSplit.UnrealLoads/Games/GameSupport.cs
@@ -23,7 +23,7 @@ namespace LiveSplit.UnrealLoads.Games
 		UnpauseGameTime
 	}
 
-	abstract class GameSupport
+	public abstract class GameSupport
 	{
 		public abstract HashSet<string> GameNames { get; }
 

--- a/LiveSplit.UnrealLoads/IGameMemory.cs
+++ b/LiveSplit.UnrealLoads/IGameMemory.cs
@@ -1,0 +1,19 @@
+﻿using System;
+
+namespace LiveSplit.UnrealLoads
+{
+	public interface IGameMemory
+	{
+		event EventHandler OnLoadEnded;
+		event EventHandler OnLoadStarted;
+		event MapChangeEventHandler OnMapChange;
+		event EventHandler OnReset;
+		event EventHandler OnSplit;
+		event EventHandler OnStart;
+
+		void StartMonitoring();
+		void Stop();
+	}
+
+	public delegate void MapChangeEventHandler(object sender, string prevMap, string nextMap);
+}

--- a/LiveSplit.UnrealLoads/IUnrealLoadsSettings.cs
+++ b/LiveSplit.UnrealLoads/IUnrealLoadsSettings.cs
@@ -1,0 +1,21 @@
+﻿using System.Collections.Generic;
+using System.Windows.Forms;
+using System.Xml;
+
+namespace LiveSplit.UnrealLoads
+{
+	public interface IUnrealLoadsSettings
+	{
+		bool AutoReset { get; set; }
+		bool AutoSplitOncePerMap { get; set; }
+		bool AutoSplitOnMapChange { get; set; }
+		bool AutoStart { get; set; }
+		bool DbgShowMap { get; set; }
+		IList<Map> Maps { get; }
+
+		XmlNode GetSettings(XmlDocument doc);
+		void SetSettings(XmlNode settings);
+
+		Control UserControl { get; }
+	}
+}

--- a/LiveSplit.UnrealLoads/LiveSplit.UnrealLoads.csproj
+++ b/LiveSplit.UnrealLoads/LiveSplit.UnrealLoads.csproj
@@ -73,6 +73,8 @@
     <Compile Include="Games\UnrealGold.cs" />
     <Compile Include="Games\WheelOfTime.cs" />
     <Compile Include="Hooks.cs" />
+    <Compile Include="IGameMemory.cs" />
+    <Compile Include="IUnrealLoadsSettings.cs" />
     <Compile Include="Map.cs" />
     <Compile Include="PE.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/LiveSplit.UnrealLoads/UnrealLoadsComponent.cs
+++ b/LiveSplit.UnrealLoads/UnrealLoadsComponent.cs
@@ -15,14 +15,13 @@ namespace LiveSplit.UnrealLoads
 	{
 		public override string ComponentName => "UnrealLoads";
 
-		public UnrealLoadsSettings Settings { get; set; }
+		private readonly IUnrealLoadsSettings Settings;
+		private readonly ITimerModel _timer;
+		private readonly IGameMemory _gameMemory;
+		private readonly LiveSplitState _state;
+		private readonly HashSet<string> _splitHistory;
 
-		TimerModel _timer;
-		GameMemory _gameMemory;
-		LiveSplitState _state;
-		HashSet<string> _splitHistory;
-
-		public UnrealLoadsComponent(LiveSplitState state)
+		public UnrealLoadsComponent(LiveSplitState state, ITimerModel timer, IGameMemory gameMemory, IUnrealLoadsSettings settings)
 		{
 			bool debug = false;
 #if DEBUG
@@ -31,14 +30,13 @@ namespace LiveSplit.UnrealLoads
 			Trace.WriteLine("[NoLoads] Using LiveSplit.UnrealLoads component version " + Assembly.GetExecutingAssembly().GetName().Version + " " + ((debug) ? "Debug" : "Release") + " build");
 
 			_state = state;
-			_timer = new TimerModel { CurrentState = state };
+			_timer = timer;
 			_splitHistory = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-
-			Settings = new UnrealLoadsSettings(_state);
+			Settings = settings;
 
 			_state.OnStart += _state_OnStart;
 
-			_gameMemory = new GameMemory();
+			_gameMemory = gameMemory;
 			_gameMemory.OnReset += gameMemory_OnReset;
 			_gameMemory.OnStart += gameMemory_OnStart;
 			_gameMemory.OnSplit += _gameMemory_OnSplit;
@@ -144,7 +142,7 @@ namespace LiveSplit.UnrealLoads
 
 		public override XmlNode GetSettings(XmlDocument document) => Settings.GetSettings(document);
 
-		public override Control GetSettingsControl(LayoutMode mode) => Settings;
+		public override Control GetSettingsControl(LayoutMode mode) => Settings.UserControl;
 
 		public override void SetSettings(XmlNode settings) => Settings.SetSettings(settings);
 

--- a/LiveSplit.UnrealLoads/UnrealLoadsFactory.cs
+++ b/LiveSplit.UnrealLoads/UnrealLoadsFactory.cs
@@ -1,6 +1,8 @@
 ﻿using LiveSplit.Model;
 using LiveSplit.UI.Components;
+using LiveSplit.UnrealLoads.Games;
 using System;
+using System.Collections.Generic;
 using System.Reflection;
 
 namespace LiveSplit.UnrealLoads
@@ -13,7 +15,10 @@ namespace LiveSplit.UnrealLoads
 
 		public ComponentCategory Category => ComponentCategory.Control;
 
-		public IComponent Create(LiveSplitState state) => new UnrealLoadsComponent(state);
+		public IComponent Create(LiveSplitState state) => new UnrealLoadsComponent(state,
+			new TimerModel { CurrentState = state },
+			new GameMemory(_supportedGames),
+			new UnrealLoadsSettings(state, _supportedGames));
 
 		public string UpdateName => ComponentName;
 
@@ -22,5 +27,21 @@ namespace LiveSplit.UnrealLoads
 		public Version Version => Assembly.GetExecutingAssembly().GetName().Version;
 
 		public string XMLURL => UpdateURL + "Components/update.LiveSplit.UnrealLoads.xml";
+
+		private readonly IList<GameSupport> _supportedGames = new GameSupport[]
+		{
+			new HarryPotter1(),
+			new HarryPotter2(),
+			new HarryPotter3(),
+			new Shrek2(),
+			new WheelOfTime(),
+			new UnrealGold(),
+			new SplinterCell3(),
+			new SplinterCell(),
+			new MobileForces(),
+			new XCOM_Enforcer(),
+			new DS9TheFallen(),
+			new KlingonHonorGuard()
+		};
 	}
 }


### PR DESCRIPTION
When loading a save it is currently triggering a map exit split (loading a save == loading a map). I made it not split anymore when entering an unlisted map.
This might break exit map splits for some games which don't have all maps listed, but I think most people use map entry splits anyway.