### PR TITLE
Harry Potter 2: unpause game time while pausing the game during cutscene skips

### DIFF
--- a/LiveSplit.UnrealLoads/Games/HarryPotter2.cs
+++ b/LiveSplit.UnrealLoads/Games/HarryPotter2.cs
@@ -68,6 +68,7 @@ namespace LiveSplit.UnrealLoads.Games
 		};
 
 		private readonly MemoryWatcher<bool> _isSkippingCut = new MemoryWatcher<bool>(new DeepPointer("Engine.dll", 0x2E2DFC, 0x5C));
+		private readonly MemoryWatcher<bool> _isGamePaused = new MemoryWatcher<bool>(new DeepPointer("Engine.dll", 0x2E2DFC, 0x50));
 		private readonly HashSet<int> _moduleMemorySizes = new HashSet<int>
 		{
 			704512,
@@ -87,6 +88,7 @@ namespace LiveSplit.UnrealLoads.Games
 		public override TimerAction[] OnUpdate(Process game, MemoryWatcherList watchers)
 		{
 			_isSkippingCut.Update(game);
+			_isGamePaused.Update(game);
 			var map = (StringWatcher)watchers["map"];
 
 			if (_isSkippingCut.Changed && _isSkippingCut.Current
@@ -100,7 +102,7 @@ namespace LiveSplit.UnrealLoads.Games
 
 		public override bool? IsLoading(MemoryWatcherList watchers)
 		{
-			if (_isSkippingCut.Current)
+			if (_isSkippingCut.Current && !_isGamePaused.Current)
 				return true;
 
 			return null;


### PR DESCRIPTION
Currently it's possible to indefinitely pause the Game Time timer by pausing game during cutscene skip screens, which players used to get advantage. This change causes timer to unpause, if the player pauses game during cutscene skip.
This change was requested by game's moderators, they currently wait for this change to get approved, until they announce it to the community. 
All current runs have been retimed to fit the new timing method.