### PR TITLE
Add The Heat of War support

### DIFF
--- a/LiveSplit.UnrealLoads/Games/TheHeatOfWar.cs
+++ b/LiveSplit.UnrealLoads/Games/TheHeatOfWar.cs
@@ -12,6 +12,7 @@ namespace LiveSplit.UnrealLoads.Games
 			"THOW",
 			"The Heat Of War",
 			"WWII Combat - Iwo Jima",
+			"WWII Combat: Iwo Jima",
 			"Iwo Jima",
 			"WWII Combat"
 		};
@@ -34,22 +35,6 @@ namespace LiveSplit.UnrealLoads.Games
 			"B_09_Map",
 			"B_10_Map"
 		};
-
-		
-//		public override TimerAction[] OnMapLoad(MemoryWatcherList watchers)
-//		{
-//			var map = (StringWatcher)watchers["map"];
-//
-//			if (map != null)
-//			{
-//				if (map.Current.Equals("B_01_Map.cmf", StringComparison.OrdinalIgnoreCase))
-//				{
-//					return new TimerAction[] { TimerAction.Start };
-//				}
-//			}	
-//
-//			return null;
-//		}
 	}
 }
 

--- a/LiveSplit.UnrealLoads/Games/TheHeatOfWar.cs
+++ b/LiveSplit.UnrealLoads/Games/TheHeatOfWar.cs
@@ -1,0 +1,55 @@
+﻿using System.Collections.Generic;
+using LiveSplit.ComponentUtil;
+using System;
+using System.Diagnostics;
+
+namespace LiveSplit.UnrealLoads.Games
+{
+	class TheHeatOfWar : GameSupport
+	{
+		public override HashSet<string> GameNames { get; } = new HashSet<string>
+		{
+			"THOW",
+			"The Heat Of War",
+			"WWII Combat - Iwo Jima",
+			"Iwo Jima",
+			"WWII Combat"
+		};
+
+		public override HashSet<string> ProcessNames { get; } = new HashSet<string>
+		{
+			"iwo"
+		};
+
+		public override HashSet<string> Maps { get; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+		{
+			"B_01_Map",
+			"B_02_Map",
+			"B_03_Map",
+			"B_04_Map",
+			"B_05_Map",
+			"B_06_Map",
+			"B_07_Map",
+			"B_08_Map",
+			"B_09_Map",
+			"B_10_Map"
+		};
+
+		
+//		public override TimerAction[] OnMapLoad(MemoryWatcherList watchers)
+//		{
+//			var map = (StringWatcher)watchers["map"];
+//
+//			if (map != null)
+//			{
+//				if (map.Current.Equals("B_01_Map.cmf", StringComparison.OrdinalIgnoreCase))
+//				{
+//					return new TimerAction[] { TimerAction.Start };
+//				}
+//			}	
+//
+//			return null;
+//		}
+	}
+}
+

--- a/LiveSplit.UnrealLoads/LiveSplit.UnrealLoads.csproj
+++ b/LiveSplit.UnrealLoads/LiveSplit.UnrealLoads.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -37,9 +37,9 @@
     <RootNamespace>LiveSplit.UnrealLoads</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="LiveSplit.Core, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\LiveSplit_1.7.6\LiveSplit.Core.dll</HintPath>
+    <Reference Include="LiveSplit.Core">
+      <HintPath>..\..\..\..\Program Files\LiveSplit\LiveSplit.Core.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System" />
@@ -52,7 +52,7 @@
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="UpdateManager">
-      <HintPath>..\..\..\..\LiveSplit_1.7.6\UpdateManager.dll</HintPath>
+      <HintPath>..\..\..\..\Program Files\LiveSplit\UpdateManager.dll</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>

--- a/LiveSplit.UnrealLoads/LiveSplit.UnrealLoads.csproj
+++ b/LiveSplit.UnrealLoads/LiveSplit.UnrealLoads.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -37,9 +37,9 @@
     <RootNamespace>LiveSplit.UnrealLoads</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="LiveSplit.Core">
-      <HintPath>..\..\..\..\Program Files\LiveSplit\LiveSplit.Core.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="LiveSplit.Core, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\..\LiveSplit_1.7.6\LiveSplit.Core.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System" />
@@ -52,7 +52,7 @@
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="UpdateManager">
-      <HintPath>..\..\..\..\Program Files\LiveSplit\UpdateManager.dll</HintPath>
+      <HintPath>..\..\..\..\LiveSplit_1.7.6\UpdateManager.dll</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>
@@ -65,6 +65,7 @@
     <Compile Include="Games\HarryPotter3.cs" />
     <Compile Include="Games\HarryPotter2.cs" />
     <Compile Include="Games\KlingonHonorGuard.cs" />
+    <Compile Include="Games\TheHeatOfWar.cs" />
     <Compile Include="Games\XCOM_Enforcer.cs" />
     <Compile Include="Games\Shrek2.cs" />
     <Compile Include="Games\SplinterCell.cs" />

--- a/LiveSplit.UnrealLoads/UnrealLoadsFactory.cs
+++ b/LiveSplit.UnrealLoads/UnrealLoadsFactory.cs
@@ -41,7 +41,8 @@ namespace LiveSplit.UnrealLoads
 			new MobileForces(),
 			new XCOM_Enforcer(),
 			new DS9TheFallen(),
-			new KlingonHonorGuard()
+			new KlingonHonorGuard(),
+			new TheHeatOfWar() 
 		};
 	}
 }


### PR DESCRIPTION
Nice game that apparently started getting attention. I thought it'd be nice if could use working component to use loadless timing without the need to use ASL, which is pretty annoying for UE games.
The game uses UnrealEngine 2.0 engine, and was released under 2 titles - "The Heat Of War" and "WWII Combat - Iwo Jima"
WIP, because we're still not sure if it's possible to add reasonable AutoStart with current ruleset