### PR TITLE
Adding better support for Shrek 2 (PC)

### DIFF
--- a/LiveSplit.UnrealLoads/Games/Shrek2.cs
+++ b/LiveSplit.UnrealLoads/Games/Shrek2.cs
@@ -8,12 +8,49 @@ namespace LiveSplit.UnrealLoads.Games
 	{
 		public override HashSet<string> GameNames { get; } = new HashSet<string>
 		{
-			"Shrek 2"
+			"Shrek 2 (PC)",
+			"Shrek 2 PC",
+			"Shrek 2: The Game",
+			"Shrek 2",
+			"S2PC"
 		};
 
 		public override HashSet<string> ProcessNames { get; } = new HashSet<string>
 		{
 			"game"
+		};
+		
+		public override HashSet<string> Maps { get; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+		{
+			"1_shreks_swamp",
+			"2_carriage_hijack",
+			"3_the_hunt_part1",
+			"3_the_hunt_part2",
+			"3_the_hunt_part3",
+			"3_the_hunt_part4",
+			"4_fgm_pib",
+			"5_fgm_donkey",
+			"6_hamlet",
+			"6_hamlet_mine",
+			"6_hamlet_end",
+			"7_prison_donkey",
+			"8_prison_pib",
+			"9_prison_shrek",
+			"10_castle_siege",
+			"11_fgm_battle",
+			"beanstalk_bonus",
+			"beanstalk_bonus_dawn",
+			"beanstalk_bonus_knight",
+			"book_story_1",
+			"book_story_2",
+			"book_story_3",
+			"book_story_4",
+			"credits",
+			"4_fgm_office",
+			"book_frontend",
+			"book_storybook",
+			"sh2_preamble",
+			"entry"
 		};
 
 		public override IdentificationResult IdentifyProcess(Process process)


### PR DESCRIPTION
With this change, provided I read the code correctly, should allow for making UnrealLoads be able to act as a more proper autosplitter and load remover for Shrek 2 (PC). Currently however, there's two issues I potentially see with it.

First off, loading a save splits at the moment... perhaps this is because the testing I did was without the changes here (I wouldn't know as I don't understand the library of code yet)? Second off, the autosplitter doesn't automatically split at the end of the run, which is when FGM dies (the first frame of the cutscene appearing after doing so). Obviously this is expected as there's no code in place to specifically split at that moment. I'm unaware if it's possible to attempt to autosplit with the game's CutLog or not, but if that could be possible to add, then I'd be interested in making that an option. If not, that wouldn't be a big deal. 

The save-load causing a split to occur would be a deal breaker, but again, perhaps adding a list of maps fixes this? Would need confirmation.